### PR TITLE
Add AES192 and AES256 as optional encryption methods

### DIFF
--- a/Readme
+++ b/Readme
@@ -36,3 +36,9 @@ invalid.json
 	ttl_sec: time-to-live in seconds
 	now: current time of the verifying process
 	secret: base64-encoded 32-byte key to use for signing and decryption
+
+generate_192.json, verify_192.json
+generate_256.json, verify_256.json
+
+	equivalent to generate.json and verify.json for 192-bit and 256-bit
+        AES encryption strengths

--- a/Spec.md
+++ b/Spec.md
@@ -4,14 +4,17 @@ This document describes version 0x80 (currently the only
 version) of the fernet format.
 
 Conceptually, fernet takes a user-provided *message* (an arbitrary
-sequence of bytes), a *key* (256 bits), and the current
+sequence of bytes), a *key* (256, 384 or 512 bits), and the current
 time, and produces a *token*, which contains the message in a form
 that can't be read or altered without the key.
 
 To facilitate convenient interoperability, this spec defines the
 external format of both tokens and keys.
 
-All encryption in this version is done with AES 128 in CBC mode.
+Encryption in this version is done with AES 128, 192 or 256 in CBC mode
+depending on selection of the key length. AES 128 requires a 256-bit (32 byte)
+key, AES192 requires a 384-bit (48 byte) key and AES 256 requires a
+512-bit (64 byte) key.
 
 All base 64 encoding is done with the "URL and Filename Safe"
 variant, defined in [RFC 4648](http://tools.ietf.org/html/rfc4648#section-5) as "base64url".
@@ -23,8 +26,8 @@ fields:
 
     Signing-key ‖ Encryption-key
 
-- *Signing-key*, 128 bits
-- *Encryption-key*, 128 bits
+- *Signing-key*, 128, 192 or 256 bits
+- *Encryption-key*, the same key length as *Signing-key*
 
 ## Token Format
 
@@ -48,8 +51,11 @@ complete fernet token.
 ### Version
 
 This field denotes which version of the format is being used by
-the token. Currently there is only one version defined, with the
-value 128 (0x80).
+the token. Currently there are three versions defined:
+
+- value 128 (0x80) indicating AES 128 encryption is used
+- value 160 (0xA0) indicating AES 192 encryption is used
+- value 192 (0xC0) indicating AES 256 encryption is used
 
 ### Timestamp
 
@@ -97,10 +103,10 @@ following steps, in order:
    versions of SSL/TLS (cf. [RFC 5246, section
    6.2.3.2](http://tools.ietf.org/html/rfc5246#section-6.2.3.2) for
    TLS 1.2).
-   2. Encrypt the padded message using AES 128 in CBC mode with
-   the chosen IV and user-supplied encryption-key.
+   2. Encrypt the padded message using AES in CBC mode with
+   the chosen IV and user-supplied key-length and encryption-key.
 4. Compute the HMAC field as described above using the
-user-supplied signing-key.
+user-supplied key-length and signing-key.
 5. Concatenate all fields together in the format above.
 6. base64url encode the entire token.
 
@@ -119,6 +125,6 @@ past.
 signing-key.
 5. Ensure the recomputed HMAC matches the HMAC field stored in the
 token, using a constant-time comparison function.
-6. Decrypt the ciphertext field using AES 128 in CBC mode with the
-recorded IV and user-supplied encryption-key.
+6. Decrypt the ciphertext field using AES in CBC mode with the
+recorded IV and user-supplied key-length and encryption-key.
 7. Unpad the decrypted plaintext, yielding the original message.

--- a/generate_192.json
+++ b/generate_192.json
@@ -1,6 +1,6 @@
 [
   {
-    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCpF29-CGZL2p-9kNCtLBMbkTrPO33HncHJ4DHlXW4xOg==",
+    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCSAuTSYGLb_iSZeR5MTljtE4KSC8_y46YMBa3sC5Oh1g==",
     "now": "1985-10-26T01:20:00-07:00",
     "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     "src": "hello",

--- a/generate_192.json
+++ b/generate_192.json
@@ -1,0 +1,9 @@
+[
+  {
+    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCpF29-CGZL2p-9kNCtLBMbkTrPO33HncHJ4DHlXW4xOg==",
+    "now": "1985-10-26T01:20:00-07:00",
+    "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "src": "hello",
+    "secret": "HE_GGEDrDA3L2GJBaoFPkQseOzSjAi1aPSTil0PL5p5eJwYHuvvQMPRphvTW-EUl"
+  }
+]

--- a/generate_256.json
+++ b/generate_256.json
@@ -1,0 +1,9 @@
+[
+  {
+    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq40s4zVsKfpBhtLAF3Epp6RNfJfsYWcknIhTBmWrMoO-5g==",
+    "now": "1985-10-26T01:20:00-07:00",
+    "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    "src": "hello",
+    "secret": "iad7Z_H9a0BGsWoNz-7SbDon9URcuCECWb0QbTJk2MrD8_DWQvShFXUB_MxAkSly6WbzO6DmfTF_prBYV5NL7A=="
+  }
+]

--- a/generate_256.json
+++ b/generate_256.json
@@ -1,6 +1,6 @@
 [
   {
-    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq40s4zVsKfpBhtLAF3Epp6RNfJfsYWcknIhTBmWrMoO-5g==",
+    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq41OzDC84hoWrrFKNuYe5BxbuyTRHXqTQ4H0yc5fwyaCjw==",
     "now": "1985-10-26T01:20:00-07:00",
     "iv": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     "src": "hello",

--- a/verify_192.json
+++ b/verify_192.json
@@ -1,6 +1,6 @@
 [
   {
-    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCpF29-CGZL2p-9kNCtLBMbkTrPO33HncHJ4DHlXW4xOg==",
+    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCSAuTSYGLb_iSZeR5MTljtE4KSC8_y46YMBa3sC5Oh1g==",
     "now": "1985-10-26T01:20:01-07:00",
     "ttl_sec": 60,
     "src": "hello",

--- a/verify_192.json
+++ b/verify_192.json
@@ -1,0 +1,9 @@
+[
+  {
+    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0OD5KjScoBQM_ETQ-X6ZU_vjCpF29-CGZL2p-9kNCtLBMbkTrPO33HncHJ4DHlXW4xOg==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "src": "hello",
+    "secret": "HE_GGEDrDA3L2GJBaoFPkQseOzSjAi1aPSTil0PL5p5eJwYHuvvQMPRphvTW-EUl"
+  }
+]

--- a/verify_256.json
+++ b/verify_256.json
@@ -1,6 +1,6 @@
 [
   {
-    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq40s4zVsKfpBhtLAF3Epp6RNfJfsYWcknIhTBmWrMoO-5g==",
+    "token": "wAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq41OzDC84hoWrrFKNuYe5BxbuyTRHXqTQ4H0yc5fwyaCjw==",
     "now": "1985-10-26T01:20:01-07:00",
     "ttl_sec": 60,
     "src": "hello",

--- a/verify_256.json
+++ b/verify_256.json
@@ -1,0 +1,9 @@
+[
+  {
+    "token": "oAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODwAmwKtUzbXfApKoCXvYq40s4zVsKfpBhtLAF3Epp6RNfJfsYWcknIhTBmWrMoO-5g==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "src": "hello",
+    "secret": "iad7Z_H9a0BGsWoNz-7SbDon9URcuCECWb0QbTJk2MrD8_DWQvShFXUB_MxAkSly6WbzO6DmfTF_prBYV5NL7A=="
+  }
+]


### PR DESCRIPTION
Add AES192 and AES256 as supported encryption methods.
Add version bytes to distinguish between AES128, AES192 and AES256 encryption in tokens.